### PR TITLE
Allow custom Public NODE and Port

### DIFF
--- a/ConnectionManager.cs
+++ b/ConnectionManager.cs
@@ -123,7 +123,7 @@ namespace PlenteumWallet
             {
                 //There's no local daemon process running, so start service with a remote node
                 //gui.plenteum.com -round-robin DNS  
-                p.StartInfo.Arguments = CLIEncoder.Encode(new string[] { "-w", wallet, "-p", pass, "--rpc-password", _rpcRand, "--daemon-address", "two.public.plenteum.com", "--daemon-port", "44016" });
+                p.StartInfo.Arguments = CLIEncoder.Encode(new string[] { "-w", wallet, "-p", pass, "--rpc-password", _rpcRand, "--daemon-address", Properties.Settings.Default.deIP, "--daemon-port", Properties.Settings.Default.dePort });
             }
             else
             {

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -106,5 +106,37 @@ namespace PlenteumWallet.Properties {
                 this["defaultFee"] = value;
             }
         }
+        // ********
+        // Add your own Wallet NODE
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("two.public.plenteum.com")]
+        public string deIP
+        {
+            get
+            {
+                return ((string)(this["deIP"]));
+            }
+            set
+            {
+                this["deIP"] = value;
+            }
+        }
+        // ADD NODE PORT
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("44016")]
+        public string dePort
+        {
+            get
+            {
+                return ((string)(this["dePort"]));
+            }
+            set
+            {
+                this["dePort"] = value;
+            }
+        }
+        // End of extras
     }
 }


### PR DESCRIPTION
Added the ability to change to a custom NODE and Port, if you don't to use the default two.public.plenteum.com server.  However, two.public.plenteum.com IS still set as default.  Changes are available in the PlenteumWallet.exe.config file.
Please double check my work, I don't code in C#.